### PR TITLE
Fix Publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ stages:
   - name: "deploy-pypi"
     if: "tag IS present"
 
-if: "type IN (pull_request)" # Add in "branch" as an option if desired for branch testing as well
 language: "python"
 services:
   - "docker"


### PR DESCRIPTION
The previous Travis limited what was being built on and caused the tag to not be present to build the wheel. This removes the Pull in and builds for everything.