### PR TITLE
Updates version and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v2.0.0
+
+- (#18) Migrates functions to new NTC netutils library, which is removing methods previously available:
+  - compliance
+  - make_folder
+  - hostname_resolves
+  - test_tcp_port
+  - is_ip
+
 ## v0.1.0 - 2020-12-27
 
 Initial release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nornir-nautobot"
-version = "1.0.1"
+version = "2.0.0"
 description = "Nornir Nautobot"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Release 2.0.0 updates

- (#18) Migrates functions to new NTC netutils library, which is removing methods previously available:  
  - compliance
  - make_folder 
  - hostname_resolves  
  - test_tcp_port  
  - is_ip

Major release due to previously available methods being moved to a new library. Technically would break if someone were to be using them.