### PR TITLE
Updates for Devices Without Platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.0.1
+
+- (#20) Fixes inventory failure when platform is not defined for a device
 ## v2.0.0
 
 - (#18) Migrates functions to new NTC netutils library, which is removing methods previously available:

--- a/nornir_nautobot/plugins/inventory/nautobot.py
+++ b/nornir_nautobot/plugins/inventory/nautobot.py
@@ -151,19 +151,13 @@ class NautobotInventory:
             host["name"] = device.name or str(device.id)
             host["groups"] = []
 
-            # Check to see if a platform has been defined
-            if hasattr(device.platform, "slug"):
-                host_platform = device.platform.slug
-            else:
-                host_platform = None
-
             # Add host to hosts by name first, ID otherwise - to string
             hosts[device.name or str(device.id)] = _set_host(  # pylint: disable=unsupported-assignment-operation
                 data=host["data"],
                 name=host["name"],
                 groups=host["groups"],
                 host=host,
-                host_platform=host_platform,
+                host_platform=getattr(device.platform, "slug", None),
             )
 
         return Inventory(hosts=hosts, groups=groups, defaults=defaults)

--- a/nornir_nautobot/plugins/inventory/nautobot.py
+++ b/nornir_nautobot/plugins/inventory/nautobot.py
@@ -151,13 +151,19 @@ class NautobotInventory:
             host["name"] = device.name or str(device.id)
             host["groups"] = []
 
+            # Check to see if a platform has been defined
+            if hasattr(device.platform, "slug"):
+                host_platform = device.platform.slug
+            else:
+                host_platform = None
+
             # Add host to hosts by name first, ID otherwise - to string
             hosts[device.name or str(device.id)] = _set_host(  # pylint: disable=unsupported-assignment-operation
                 data=host["data"],
                 name=host["name"],
                 groups=host["groups"],
                 host=host,
-                host_platform=device.platform.slug,
+                host_platform=host_platform,
             )
 
         return Inventory(hosts=hosts, groups=groups, defaults=defaults)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nornir-nautobot"
-version = "2.0.0"
+version = "2.0.1"
 description = "Nornir Nautobot"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"

--- a/tests/unit/mocks/01_get_devices.json
+++ b/tests/unit/mocks/01_get_devices.json
@@ -1,5 +1,5 @@
 {
-    "count": 12,
+    "count": 3,
     "next": null,
     "previous": null,
     "results": [
@@ -28,12 +28,7 @@
                 "slug": "network"
             },
             "tenant": null,
-            "platform": {
-                "id": 2,
-                "url": "http://nautobot-demo.com/api/dcim/platforms/2/",
-                "name": "Cisco IOS",
-                "slug": "ios"
-            },
+            "platform": null,
             "serial": "9ZYX8XZUMP0AF69YGO5Z5",
             "asset_tag": null,
             "site": {

--- a/tests/unit/test_nautobot_inventory.py
+++ b/tests/unit/test_nautobot_inventory.py
@@ -166,3 +166,82 @@ def test_device_required_properties():
     # Verify expected result
     for task_result in nornir_task_result:
         assert nornir_task_result[task_result].result == "ios"
+
+
+def test_nornir_nautobot_device_count(nornir_nautobot_class):
+    # Import mock requests
+    with Mocker() as mock:
+        load_api_calls(mock)
+        test_nornir = InitNornir(
+            inventory={
+                "plugin": "NautobotInventory",
+                "options": {
+                    "nautobot_url": "http://mock.example.com",
+                    "nautobot_token": "0123456789abcdef01234567890",
+                },
+            },
+        )
+
+    # Verify that the length of the inventory is 3 devices
+    assert len(test_nornir.inventory.hosts) == 3
+
+
+@pytest.mark.parametrize(
+    "device, expected_platform", [("den-dist01", None), ("den-wan01", "ios"), ("den-dist02", "ios")]
+)
+def test_nornir_nautobot_device_platform(device, expected_platform):
+    # Import mock requests
+    with Mocker() as mock:
+        load_api_calls(mock)
+        test_nornir = InitNornir(
+            inventory={
+                "plugin": "NautobotInventory",
+                "options": {
+                    "nautobot_url": "http://mock.example.com",
+                    "nautobot_token": "0123456789abcdef01234567890",
+                },
+            },
+        )
+
+    assert test_nornir.inventory.hosts[device].platform == expected_platform
+
+
+@pytest.mark.parametrize(
+    "device, expected_hostname", [("den-dist01", "10.17.1.2"), ("den-wan01", "10.16.0.2"), ("den-dist02", "10.17.1.6")]
+)
+def test_nornir_nautobot_device_hostname(device, expected_hostname):
+    # Import mock requests
+    with Mocker() as mock:
+        load_api_calls(mock)
+        test_nornir = InitNornir(
+            inventory={
+                "plugin": "NautobotInventory",
+                "options": {
+                    "nautobot_url": "http://mock.example.com",
+                    "nautobot_token": "0123456789abcdef01234567890",
+                },
+            },
+        )
+
+    assert test_nornir.inventory.hosts[device].hostname == expected_hostname
+
+
+# Setup of groups for a future PR
+@pytest.mark.parametrize(
+    "device, expected_groups", [("den-dist01", []), ("den-wan01", []), ("den-dist02", [])]
+)
+def test_nornir_nautobot_device_hostname(device, expected_groups):
+    # Import mock requests
+    with Mocker() as mock:
+        load_api_calls(mock)
+        test_nornir = InitNornir(
+            inventory={
+                "plugin": "NautobotInventory",
+                "options": {
+                    "nautobot_url": "http://mock.example.com",
+                    "nautobot_token": "0123456789abcdef01234567890",
+                },
+            },
+        )
+
+    assert test_nornir.inventory.hosts[device].groups == expected_groups

--- a/tests/unit/test_nautobot_inventory.py
+++ b/tests/unit/test_nautobot_inventory.py
@@ -168,7 +168,7 @@ def test_device_required_properties():
         assert nornir_task_result[task_result].result == "ios"
 
 
-def test_nornir_nautobot_device_count(nornir_nautobot_class):
+def test_nornir_nautobot_device_count():
     # Import mock requests
     with Mocker() as mock:
         load_api_calls(mock)
@@ -227,10 +227,8 @@ def test_nornir_nautobot_device_hostname(device, expected_hostname):
 
 
 # Setup of groups for a future PR
-@pytest.mark.parametrize(
-    "device, expected_groups", [("den-dist01", []), ("den-wan01", []), ("den-dist02", [])]
-)
-def test_nornir_nautobot_device_hostname(device, expected_groups):
+@pytest.mark.parametrize("device, expected_groups", [("den-dist01", []), ("den-wan01", []), ("den-dist02", [])])
+def test_nornir_nautobot_device_groups(device, expected_groups):
     # Import mock requests
     with Mocker() as mock:
         load_api_calls(mock)


### PR DESCRIPTION
## Fixes #20 

## Approach

1. Changed a JSON entry for devices to be `"platform": null,`, matching what is on an API call to `dcim/devices` when a device has no platform assigned
2. Validated that the error NoneType has no attribute "slug"
3. Created tests that validated this
4. Added a check if the platform attribute exists, assigning the attribute to a new var
5. If the attribute does not exist, then assign None to `host_platform`
6. Added additional tests of device data
