### PR TITLE
Added code to close connections per host when backup task is ran

### DIFF
--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -63,6 +63,8 @@ class NautobotNornirDriver:
         except NornirSubTaskError as exc:
             logger.log_failure(obj, f"Failed with a unknown issue. `{exc.result.exception}`")
             raise NornirNautobotException()
+        finally:
+            task.host.close_connection("napalm")
 
         if result[0].failed:
             logger.log_failure(obj, f"Failed with a unknown issue. `{str(result.exception)}`")
@@ -246,6 +248,8 @@ class NetmikoNautobotNornirDriver(NautobotNornirDriver):
 
             logger.log_failure(obj, f"Failed with an unknown issue. `{exc.result.exception}`")
             raise NornirNautobotException()
+        finally:
+            task.host.close_connection("netmiko")
 
         if result[0].failed:
             return result


### PR DESCRIPTION
This PR addresses #60. @jmcgill298 and I found that closing the connection to the device within the `get_config` function greatly reduced CPU and memory usage. This may not be the best place to put it, but we feel this is at least a step in the right direction. We wanted to get this PR in to get some feedback from you all.