### PR TITLE
Update nornir logging

### DIFF
--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -417,7 +417,7 @@ class NapalmDefault(DispatcherMixin):
         )
 
         if push_result.diff:
-            logger.info(f"```\nDiff: {push_result.diff}\n```", extra={"object": obj})
+            logger.info(f"Diff:\n```\n_{push_result.diff}\n```", extra={"object": obj})
 
         logger.info("Config merge ended", extra={"object": obj})
         return Result(

--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -415,6 +415,10 @@ class NapalmDefault(DispatcherMixin):
             f"result: {push_result[0].result}, changed: {push_result.changed}",
             extra={"object": obj},
         )
+
+        if push_result.diff:
+            logger.info(f"```\nDiff: {push_result.diff}\n```", extra={"object": obj})
+
         logger.info("Config merge ended", extra={"object": obj})
         return Result(
             host=task.host,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,8 @@ notes = """,
     """
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 testpaths = "tests/"


### PR DESCRIPTION
Add `result.diff` logging to merge_config job. I was only able to test against an Arista device - I believe the output would be identical for other platforms, but it's worth testing. Do we have other platforms available somewhere to test against? Arista screenshot below. 

Attempts to resolve https://github.com/nautobot/nautobot-plugin-golden-config/issues/620. Let me know if that issue should be moved to this repo.


<img width="972" alt="Screenshot 2023-11-01 at 8 17 22 PM" src="https://github.com/nautobot/nornir-nautobot/assets/80693460/6373f9cb-89f2-4a2c-965d-5b2a2f014b49">

