### PR TITLE
add a can_diff arg to avoid logging sensitive data

### DIFF
--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -371,6 +371,7 @@ class NapalmDefault(DispatcherMixin):
         logger,
         obj,
         config: str,
+        can_diff: bool = True,
     ) -> Result:
         """Send configuration to merge on the device.
 
@@ -412,7 +413,10 @@ class NapalmDefault(DispatcherMixin):
         )
 
         if push_result.diff:
-            logger.info(f"Diff:\n```\n_{push_result.diff}\n```", extra={"object": obj})
+            if can_diff:
+                logger.info(f"Diff:\n```\n_{push_result.diff}\n```", extra={"object": obj})
+            else:
+                logger.warning("Diff was requested but may include sensitive data. Ignoring...", extra={"object": obj})
 
         logger.info("Config merge ended", extra={"object": obj})
         return Result(


### PR DESCRIPTION
If an post processing or sensitive data is being changed, you may not want to display the diff to job log entries, standard python loggers, etc. Allow for an override to skip the debug print if you set it.