### PR TITLE
Release 3.3.1

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.3.1
+
+* [179] Fixes Default Netmiko merge_config missing can_diff argument.
+
+**Full Changelog**: https://github.com/nautobot/nornir-nautobot/compare/v3.3.0...v3.3.1
+
 ## 3.3.0
 
 * [170] Add merge_config method to the Default Netmiko dispatcher.

--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -533,12 +533,13 @@ class NetmikoDefault(DispatcherMixin):
         return Result(host=task.host, result={"config": processed_config})
 
     @classmethod
-    def merge_config(
+    def merge_config(  # pylint: disable=too-many-positional-arguments
         cls,
         task: Task,
         logger,
         obj,
         config: str,
+        can_diff: bool = True,
     ) -> Result:
         """Send configuration to merge on the device.
 
@@ -582,7 +583,13 @@ class NetmikoDefault(DispatcherMixin):
         )
 
         if push_result.diff:
-            logger.info(f"Diff:\n```\n_{push_result[0].diff}\n```", extra={"object": obj})
+            if can_diff:
+                logger.info(f"Diff:\n```\n_{push_result.diff}\n```", extra={"object": obj})
+            else:
+                logger.warning(
+                    "Diff was requested but may include sensitive data. Ignoring...",
+                    extra={"object": obj},
+                )
 
         logger.info("Config merge ended", extra={"object": obj})
         try:

--- a/nornir_nautobot/plugins/tasks/dispatcher/mikrotik_routeros.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/mikrotik_routeros.py
@@ -162,6 +162,7 @@ class NetmikoMikrotikRouteros(NetmikoDefault):
         logger,
         obj,
         config: str,
+        can_diff: bool = True,
     ) -> Result:
         """Send configuration to merge on the device.
 

--- a/nornir_nautobot/plugins/tasks/dispatcher/ruckus_fastiron.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/ruckus_fastiron.py
@@ -15,7 +15,7 @@ class NetmikoRuckusFastiron(NetmikoDefault):
     config_command = "show running-config"
 
     @staticmethod
-    def merge_config(task: Task, logger, obj, config: str) -> Result:
+    def merge_config(task: Task, logger, obj, config: str, can_diff: bool = True) -> Result:
         """Send configuration to merge on the device.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nornir-nautobot"
-version = "3.3.0"
+version = "3.3.1"
 description = "Nornir Nautobot"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"


### PR DESCRIPTION
## 3.3.1

* [179] Fixes Default Netmiko merge_config missing can_diff argument.

**Full Changelog**: https://github.com/nautobot/nornir-nautobot/compare/v3.3.0...v3.3.1