### PR TITLE
Fix plugins in mkdocs.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   black:
     env:
       INVOKE_LOCAL: "True"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
@@ -20,7 +20,7 @@ jobs:
       - name: "Linting: Black"
         run: "invoke black"
   bandit:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     env:
       INVOKE_LOCAL: "True"
     steps:
@@ -37,7 +37,7 @@ jobs:
     needs:
       - "black"
   pydocstyle:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     env:
       INVOKE_LOCAL: "True"
     steps:
@@ -54,7 +54,7 @@ jobs:
     needs:
       - "black"
   flake8:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     env:
       INVOKE_LOCAL: "True"
     steps:
@@ -71,7 +71,7 @@ jobs:
     needs:
       - "black"
   yamllint:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     env:
       INVOKE_LOCAL: "True"
     steps:
@@ -88,7 +88,7 @@ jobs:
     needs:
       - "black"
   build:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
@@ -106,7 +106,7 @@ jobs:
       - "flake8"
       - "yamllint"
   pylint:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
@@ -127,7 +127,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     env:
       PYTHON_VER: "${{ matrix.python-version }}"
     steps:
@@ -147,7 +147,7 @@ jobs:
       - "pylint"
   publish_gh:
     name: "Publish to GitHub"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
       - name: "Check out repository code"
@@ -176,7 +176,7 @@ jobs:
       - "pytest"
   publish_pypi:
     name: "Push Package to PyPI"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
       - name: "Check out repository code"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,8 @@ extra:
   generator: true
 
 markdown_extensions:
+  - "markdown_version_annotations":
+      admonition_tag: "???"
   - "admonition"
   - "toc":
       permalink: true
@@ -57,7 +59,6 @@ markdown_extensions:
   - "footnotes"
 plugins:
   - "search"
-  - "mkdocs-version-annotations"
 
 nav:
   - Overview: "index.md"


### PR DESCRIPTION
Fixing RTD build error:

```
ERROR   -  Config value 'plugins': The "mkdocs-version-annotations" plugin is not installed
```

Also switches from deprecated GHA image `ubuntu-20.04` to `ubuntu-latest` (which is the latest LTS, 24.04).