### PR TITLE
Re-add Exception and stacktrace to error message for E1010

### DIFF
--- a/nornir_nautobot/constants.py
+++ b/nornir_nautobot/constants.py
@@ -71,7 +71,7 @@ ERROR_CODES = {
     "E1010": ErrorCode(
         troubleshooting="Coming soon....",
         description="Coming soon....",
-        error_message="Undefined variable in Jinja2 template",
+        error_message="Undefined variable in Jinja2 template - ``{exc.result.exception}``\n```\n{stack_trace}\n```",
         recommendation="Coming soon....",
     ),
     "E1011": ErrorCode(


### PR DESCRIPTION
This PR corrects the regression that erased the stacktrace and exception being included in the logging message.