### PR TITLE
Update napalm pin

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2640,4 +2640,4 @@ mikrotik-driver = ["routeros-api"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.13"
-content-hash = "a40fa9c8fb1adcfa4221bf994b14616023246428223d387f5e266c710bdc3cf6"
+content-hash = "970f3027f781f2c257c31a4627aadb0a1fe23b677b4fabd134ed4d7b72d2eee2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ routeros-api = {version = "^0.17.0", optional = true}
 httpx = ">=0.23.0,<=0.27.0"
 nornir-scrapli = "^2025.1.30"
 netmiko = "^4.4.0"
-napalm = "^5.0.0"
+napalm = ">=4.1.0,<6.0.0"
 scrapli = ">=2024.01.30"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
# Closes: #202

## What's Changed

Matched napalm pin to what is in Nautobot Core, allowing for newer versions of napalm (and disallowing older versions).
