### PR TITLE
Adding get_command_with_prompts to NetmikoDefault

### DIFF
--- a/changes/210.added
+++ b/changes/210.added
@@ -1,0 +1,1 @@
+Added `get_command_with_prompts` to the `NetmikoDefault` dispatcher for sending commands and reacting to prompts.

--- a/docs/user/task.md
+++ b/docs/user/task.md
@@ -167,6 +167,40 @@ def command_to_filename(command, replacement="_"):
 
 This ensures consistent and safe naming of command output files across different operating systems and Git repositories.
 
+## Reacting to Prompts
+
+The Netmiko dispatcher has a method called `get_command_with_prompts` that can be used to react to prompts.
+
+Let's say we wanted to mimic the following interaction with a network device:
+
+```text
+my-device# copy scp: bootflash:
+Enter source filename: my-files/test.txt
+Enter vrf (If no input, current vrf 'default' is considered): management
+Enter hostname for the scp server: 192.0.2.3
+Enter username: ntc
+ntc@192.0.2.3's password:
+test.txt                                   100%    0     0.0KB/s   00:00
+Copy complete, now saving to disk (please wait)...
+my-device#
+```
+
+We could use the following prompts (order does not matter):
+
+```python
+prompts = {
+    "enter source filename:": "my-files/test.txt",
+    "enter vrf": "management",
+    "enter hostname:": "192.0.2.3",
+    "enter username:": "ntc",
+    "password:": "ntc123",
+}
+```
+
+You must provide all the expected prompts. Any unexpected prompt, besides the default device prompt, will trigger an escape sequence being sent to the device to break out of the current prompt. By default, the escape sequence is `chr(3)`, which is the `Ctrl-C` sequence. You can override this by passing the `escape_sequence` keyword argument.
+
+By default, the flags added to re.search are `re.IGNORECASE`. You can override this by passing the `regex_flags` keyword argument.
+
 ## Environment Variables
 
 | Environment Variable | Explanation |

--- a/docs/user/task.md
+++ b/docs/user/task.md
@@ -185,16 +185,25 @@ Copy complete, now saving to disk (please wait)...
 my-device#
 ```
 
-We could use the following prompts (order does not matter):
+We could use the following example:
 
 ```python
-prompts = {
-    "enter source filename:": "my-files/test.txt",
-    "enter vrf": "management",
-    "enter hostname:": "192.0.2.3",
-    "enter username:": "ntc",
-    "password:": "ntc123",
+command = "copy scp: bootflash:"
+prompt_responses = {
+    r"(.*)filename[:]?": "my-files/test.txt",
+    r"(.*)vrf[:]?": "management",
+    r"(.*)hostname[:]?": "192.0.2.3",
+    r"(.*)username[:]?": "ntc",
+    r"(.*)password[:]?": "ntc123",
 }
+task.run(
+    task=dispatcher,
+    obj=obj,
+    logger=logger,
+    method="get_command_with_prompts",
+    command=command,
+    prompt_responses=prompt_responses,
+)
 ```
 
 You must provide all the expected prompts. Any unexpected prompt, besides the default device prompt, will trigger an escape sequence being sent to the device to break out of the current prompt. By default, the escape sequence is `chr(3)`, which is the `Ctrl-C` sequence. You can override this by passing the `escape_sequence` keyword argument.

--- a/nornir_nautobot/constants.py
+++ b/nornir_nautobot/constants.py
@@ -245,6 +245,12 @@ ERROR_CODES = {
         error_message=JINJA_ERRORS,
         recommendation="Use a valid jinja filter, common reasons this error occurs include typos or jinja filter is not loaded into the Nautobot worker or web server.",
     ),
+    "E1035": ErrorCode(
+        troubleshooting="Verify that the username and password are correct.",
+        description="The authentication credentials were not accepted.",
+        error_message="Discovered `% Authentication failed` in the output",
+        recommendation="Ensure that the username and password are correct.",
+    ),
 }
 
 EXCEPTION_TO_ERROR_MAPPER = {

--- a/nornir_nautobot/constants.py
+++ b/nornir_nautobot/constants.py
@@ -251,6 +251,12 @@ ERROR_CODES = {
         error_message="Discovered `% Authentication failed` in the output",
         recommendation="Ensure that the username and password are correct.",
     ),
+    "E1036": ErrorCode(
+        troubleshooting="Verify that all expected prompts are defined in the prompts dictionary.",
+        description="A prompt was encountered that was not defined in the prompts dictionary.",
+        error_message="No prompt matched for ```\n{last_output}\n```",
+        recommendation="Verify that all expected prompts are defined in the prompts dictionary.",
+    ),
 }
 
 EXCEPTION_TO_ERROR_MAPPER = {

--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -851,10 +851,11 @@ class NetmikoDefault(DispatcherMixin):
                     # If we matched a prompt, we need to start the loop again to handle any subsequent prompts
                     break
             else:
-                logger.error(f"No prompt matched for ```\n{last_output}\n```")
+                error_msg = get_error_message("E1036", last_output=last_output)
+                logger.error(error_msg)
+                logger.debug(f"Sending escape sequence: {escape_sequence}")
                 last_output = net_connect.send_command_timing(escape_sequence, **kwargs)
-                full_output += last_output
-                break
+                raise NornirNautobotException(error_msg)
 
         return Result(host=task.host, result={"output": full_output})
 

--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -809,7 +809,7 @@ class NetmikoDefault(DispatcherMixin):
         logger,
         obj,
         command,
-        prompts,
+        prompt_responses,
         regex_flags=re.IGNORECASE,
         escape_sequence=chr(3),  # Ctrl-C
         **kwargs,
@@ -821,7 +821,7 @@ class NetmikoDefault(DispatcherMixin):
             logger (logging.Logger): Logger that may be a Nautobot Jobs or Python logger.
             obj (Device): A Nautobot Device Django ORM object instance.
             command (str): A command to execute.
-            prompts (dict): A dictionary of regex pattern prompts and responses.
+            prompt_responses (dict): A dictionary of regex pattern prompts and responses.
             regex_flags (re.RegexFlag): Flags to pass to re.search.
             escape_sequence (str): The escape sequence to send if no prompt is matched.
             kwargs (dict): Additional keyword arguments to pass to Netmiko.
@@ -843,7 +843,7 @@ class NetmikoDefault(DispatcherMixin):
                 logger.debug("Base prompt found. Command complete.")
                 break
 
-            for prompt, response in prompts.items():
+            for prompt, response in prompt_responses.items():
                 if re.search(prompt, last_output, regex_flags):
                     logger.debug(f"Matched prompt: {prompt}")
                     last_output = net_connect.send_command_timing(response, strip_prompt=False, **kwargs)

--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -741,7 +741,7 @@ class NetmikoDefault(DispatcherMixin):
                     logger.error(error_msg, extra={"object": obj})
                     raise NornirNautobotException(error_msg)
         except NornirSubTaskError as exc:
-            error_code = EXCEPTION_TO_ERROR_MAPPER.get(type(exc), "E1016")
+            error_code = EXCEPTION_TO_ERROR_MAPPER.get(type(exc), "E1014")
             error_msg = get_error_message(error_code, exc=exc)
             logger.error(error_msg, extra={"object": obj})
             raise NornirNautobotException(error_msg)
@@ -795,7 +795,7 @@ class NetmikoDefault(DispatcherMixin):
                         raise NornirNautobotException(error_msg)
                 command_results.update({command: result[0].result})
             except NornirSubTaskError as exc:
-                error_code = EXCEPTION_TO_ERROR_MAPPER.get(type(exc.result.exception), "E1016")
+                error_code = EXCEPTION_TO_ERROR_MAPPER.get(type(exc.result.exception), "E1014")
                 error_msg = get_error_message(error_code, exc=exc)
                 logger.error(error_msg, extra={"object": obj})
                 raise NornirNautobotException(error_msg)
@@ -953,7 +953,7 @@ class ScrapliDefault(DispatcherMixin):
                     raise NornirNautobotException(error_msg)
                 command_results.update({command: result[0].result})
             except NornirSubTaskError as exc:
-                error_code = EXCEPTION_TO_ERROR_MAPPER.get(type(exc.result.exception), "E1016")
+                error_code = EXCEPTION_TO_ERROR_MAPPER.get(type(exc.result.exception), "E1014")
                 error_msg = get_error_message(error_code, exc=exc)
                 logger.error(error_msg, extra={"object": obj})
                 raise NornirNautobotException(error_msg)

--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -813,7 +813,7 @@ class NetmikoDefault(DispatcherMixin):
         regex_flags=re.IGNORECASE,
         escape_sequence=chr(3),  # Ctrl-C
         **kwargs,
-    ):
+    ):  # pylint: disable=too-many-positional-arguments, too-many-locals
         """A task to run a command on a device and react to resulting prompts.
 
         Args:

--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -857,7 +857,7 @@ class NetmikoDefault(DispatcherMixin):
                 last_output = net_connect.send_command_timing(escape_sequence, **kwargs)
                 raise NornirNautobotException(error_msg)
 
-        return Result(host=task.host, result={"output": full_output})
+        return Result(host=task.host, result={"output": {command: full_output}})
 
 
 class ScrapliDefault(DispatcherMixin):

--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -820,11 +820,11 @@ class NetmikoDefault(DispatcherMixin):
             task (Task): Nornir Task.
             logger (logging.Logger): Logger that may be a Nautobot Jobs or Python logger.
             obj (Device): A Nautobot Device Django ORM object instance.
-            command: A command to execute.
-            prompts: A dictionary of regex pattern prompts and responses.
-            regex_flags: Flags to pass to re.search.
-            escape_sequence: The escape sequence to send if no prompt is matched.
-            **kwargs: Additional keyword arguments to pass to netmiko.
+            command (str): A command to execute.
+            prompts (dict): A dictionary of regex pattern prompts and responses.
+            regex_flags (re.RegexFlag): Flags to pass to re.search.
+            escape_sequence (str): The escape sequence to send if no prompt is matched.
+            kwargs (dict): Additional keyword arguments to pass to Netmiko.
         """
         logger.debug(f"Executing get_command_with_prompts for {task.host.name} on {task.host.platform}")
 


### PR DESCRIPTION
Closes: #210

This PR adds a netmiko task called `get_command_with_prompts`. It is intended to be able to react to prompts on the network device rather then expecting to just complete the command and return.

In addition, I noticed the default error code for other nornir tasks was `E1016`, which returned an error message of "Saving Config Failed". I have changed these to `E1014` instead which seemed more apt.