### PR TITLE
Release v3.4.0

### DIFF
--- a/changes/+add-changelogs.housekeeping
+++ b/changes/+add-changelogs.housekeeping
@@ -1,1 +1,0 @@
-Go through changelog from before towncrier and add them for the next release.

--- a/changes/+add-release-notes.housekeeping
+++ b/changes/+add-release-notes.housekeeping
@@ -1,1 +1,0 @@
-Few last fixes for docs, a CI.

--- a/changes/+fix-doc-links.fixed
+++ b/changes/+fix-doc-links.fixed
@@ -1,1 +1,0 @@
-Fixed incorrect links throughout docs, and add missing logo.

--- a/changes/+fix-towncrier.housekeeping
+++ b/changes/+fix-towncrier.housekeeping
@@ -1,1 +1,0 @@
-Add missing towncrier_template and update poetry's towncrier settings.

--- a/changes/+remove-code-references.removed
+++ b/changes/+remove-code-references.removed
@@ -1,1 +1,0 @@
-Remove the code-references file generation and script as its not helpful in this library.

--- a/changes/185.added
+++ b/changes/185.added
@@ -1,1 +1,0 @@
-Add a check for Permission denied for role that is seen on Cisco NXOS.

--- a/changes/188.housekeeping
+++ b/changes/188.housekeeping
@@ -1,1 +1,0 @@
-Update dependencies to be more explicit.

--- a/changes/195.added
+++ b/changes/195.added
@@ -1,1 +1,0 @@
-Adds Offline command getters and generic Git dispatcher functionality for pulling in files from a Nautobot Git repository.

--- a/changes/199.fixed
+++ b/changes/199.fixed
@@ -1,1 +1,0 @@
-Create better logging for Jinja issues.

--- a/changes/201.fixed
+++ b/changes/201.fixed
@@ -1,1 +1,0 @@
-Fixed the development standards to use 2025 standards.

--- a/changes/202.fixed
+++ b/changes/202.fixed
@@ -1,1 +1,0 @@
-Relaxed multiple dependencies to allow for update up until the next major version.

--- a/changes/204.added
+++ b/changes/204.added
@@ -1,1 +1,0 @@
-Move config_command to use Netutils functionality to make it dynamic.

--- a/changes/209.documentation
+++ b/changes/209.documentation
@@ -1,1 +1,0 @@
-Updated the error code documentation for all default dispatcher error codes.

--- a/changes/210.added
+++ b/changes/210.added
@@ -1,1 +1,0 @@
-Added `get_command_with_prompts` to the `NetmikoDefault` dispatcher for sending commands and reacting to prompts.

--- a/docs/admin/release_notes/version_3.0.md
+++ b/docs/admin/release_notes/version_3.0.md
@@ -1,5 +1,46 @@
 # v3.0 Release Notes
 
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+# v3.4 Release Notes
+
+## Release Overview
+
+- Migrate the library to newest dev standards as of 2025
+- Adds Offline command getters and generic Git dispatcher functionality for pulling in files from a Nautobot Git repository.
+- Move config_command to use Netutils functionality to make it dynamic, and more flexible within Nautobot and Golden Config.
+
+## [v3.4.0 (2025-08-28)](https://github.com/networktocode/nornir-nautobot/releases/tag/v3.4.0)
+
+### Added
+
+- [#185](https://github.com/nautobot/nornir-nautobot/issues/185) - Add a check for Permission denied for role that is seen on Cisco NXOS.
+- [#195](https://github.com/nautobot/nornir-nautobot/issues/195) - Adds Offline command getters and generic Git dispatcher functionality for pulling in files from a Nautobot Git repository.
+- [#204](https://github.com/nautobot/nornir-nautobot/issues/204) - Move config_command to use Netutils functionality to make it dynamic.
+- [#210](https://github.com/nautobot/nornir-nautobot/issues/210) - Added `get_command_with_prompts` to the `NetmikoDefault` dispatcher for sending commands and reacting to prompts.
+
+### Removed
+
+- Remove the code-references file generation and script as its not helpful in this library.
+
+### Fixed
+
+- [#199](https://github.com/nautobot/nornir-nautobot/issues/199) - Create better logging for Jinja issues.
+- [#201](https://github.com/nautobot/nornir-nautobot/issues/201) - Fixed the development standards to use 2025 standards.
+- [#202](https://github.com/nautobot/nornir-nautobot/issues/202) - Relaxed multiple dependencies to allow for update up until the next major version.
+- Fixed incorrect links throughout docs, and add missing logo.
+
+### Documentation
+
+- [#209](https://github.com/nautobot/nornir-nautobot/issues/209) - Updated the error code documentation for all default dispatcher error codes.
+
+### Housekeeping
+
+- [#188](https://github.com/nautobot/nornir-nautobot/issues/188) - Update dependencies to be more explicit.
+- Add missing towncrier_template and update poetry's towncrier settings.
+- Few last fixes for docs, a CI.
+- Go through changelog from before towncrier and add them for the next release.
+
 ## 3.3.1
 
 * [179](https://github.com/nautobot/nornir-nautobot/issues/179) Fixes Default Netmiko merge_config missing can_diff argument.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nornir-nautobot"
-version = "3.3.2a0"
+version = "3.4.0"
 description = "Nornir Nautobot"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"


### PR DESCRIPTION
# v3.4 Release Notes

## Release Overview

- Migrate the library to newest dev standards as of 2025
- Adds Offline command getters and generic Git dispatcher functionality for pulling in files from a Nautobot Git repository.
- Move config_command to use Netutils functionality to make it dynamic, and more flexible within Nautobot and Golden Config.

## [v3.4.0 (2025-08-28)](https://github.com/networktocode/nornir-nautobot/releases/tag/v3.4.0)

### Added

- [#185](https://github.com/nautobot/nornir-nautobot/issues/185) - Add a check for Permission denied for role that is seen on Cisco NXOS.
- [#195](https://github.com/nautobot/nornir-nautobot/issues/195) - Adds Offline command getters and generic Git dispatcher functionality for pulling in files from a Nautobot Git repository.
- [#204](https://github.com/nautobot/nornir-nautobot/issues/204) - Move config_command to use Netutils functionality to make it dynamic.
- [#210](https://github.com/nautobot/nornir-nautobot/issues/210) - Added `get_command_with_prompts` to the `NetmikoDefault` dispatcher for sending commands and reacting to prompts.

### Removed

- Remove the code-references file generation and script as its not helpful in this library.

### Fixed

- [#199](https://github.com/nautobot/nornir-nautobot/issues/199) - Create better logging for Jinja issues.
- [#201](https://github.com/nautobot/nornir-nautobot/issues/201) - Fixed the development standards to use 2025 standards.
- [#202](https://github.com/nautobot/nornir-nautobot/issues/202) - Relaxed multiple dependencies to allow for update up until the next major version.
- Fixed incorrect links throughout docs, and add missing logo.

### Documentation

- [#209](https://github.com/nautobot/nornir-nautobot/issues/209) - Updated the error code documentation for all default dispatcher error codes.

### Housekeeping

- [#188](https://github.com/nautobot/nornir-nautobot/issues/188) - Update dependencies to be more explicit.
- Add missing towncrier_template and update poetry's towncrier settings.
- Few last fixes for docs, a CI.
- Go through changelog from before towncrier and add them for the next release.
