### PR TITLE
implement junos specific merge_config method with proper commit calls

### DIFF
--- a/changes/197.fixed
+++ b/changes/197.fixed
@@ -1,1 +1,1 @@
-Add the missing `netmiko_commit` to the JUNOS `merge_config` method.
+Add the missing `netmiko_commit` to the default `merge_config` method.

--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -19,12 +19,7 @@ from netutils.ping import tcp_ping
 from nornir.core.exceptions import NornirSubTaskError
 from nornir.core.task import Result, Task
 from nornir_napalm.plugins.tasks import napalm_configure, napalm_get
-from nornir_netmiko.tasks import (
-    netmiko_save_config,
-    netmiko_send_command,
-    netmiko_send_config,
-    netmiko_commit
-)
+from nornir_netmiko.tasks import netmiko_commit, netmiko_save_config, netmiko_send_command, netmiko_send_config
 from nornir_scrapli.tasks import send_command as scrapli_send_command
 
 from nornir_nautobot.constants import EXCEPTION_TO_ERROR_MAPPER


### PR DESCRIPTION
Don't have a Juniper to test against currently, but this should fix both the napalm merge_config and netmiko merge_config issues mentioned in #197 #155 