### PR TITLE
Release v3.6.0a1

### DIFF
--- a/docs/admin/release_notes/version_3.6.md
+++ b/docs/admin/release_notes/version_3.6.md
@@ -1,0 +1,19 @@
+
+# v3.6 Release Notes
+
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+- Dropped support for Python 3.9.
+- Added support for Python 3.13.
+
+## [v3.6.0a1 (2025-10-31)](https://github.com/networktocode/nornir-nautobot/releases/tag/v3.6.0a1)
+
+### Added
+
+- Added support for Python 3.13.
+
+### Removed
+
+- Dropped support for Python 3.9.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,6 +173,7 @@ nav:
       - Uninstall: "admin/uninstall.md"
       - Release Notes:
           - "admin/release_notes/index.md"
+          - v3.6: "admin/release_notes/version_3.6.md"
           - v3.5: "admin/release_notes/version_3.5.md"
           - v3.4: "admin/release_notes/version_3.4.md"
           - v3.0: "admin/release_notes/version_3.0.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nornir-nautobot"
-version = "3.6.0a0"
+version = "3.6.0a1"
 description = "Nornir Nautobot"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"


### PR DESCRIPTION
## [v3.6.0a1 (2025-10-31)](https://github.com/networktocode/nornir-nautobot/releases/tag/v3.6.0a1)

### Added

- Added support for Python 3.13.

### Removed

- Dropped support for Python 3.9.