### PR TITLE
bump version to 3.6.0a2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nornir-nautobot"
-version = "3.6.0a1"
+version = "3.6.0a2"
 description = "Nornir Nautobot"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"


### PR DESCRIPTION
This is required for other apps to be able to point to the git branch. Otherwise poetry will default to pulling 3.6.0a1 from pypi