### PR TITLE
Nornir inventory extended to support VMs.

### DIFF
--- a/changes/251.added
+++ b/changes/251.added
@@ -1,0 +1,1 @@
+Added Virtual Machine inventory support.

--- a/nornir_nautobot/plugins/inventory/nautobot.py
+++ b/nornir_nautobot/plugins/inventory/nautobot.py
@@ -5,7 +5,7 @@ import ipaddress
 import logging
 import os
 import sys
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Optional, Union
 
 # Other third party imports
 import pynautobot
@@ -23,6 +23,79 @@ from requests import Session
 
 # Create Logger
 logger = logging.getLogger(__name__)
+
+
+QueryFilters = Union[Dict[str, Any], None]
+
+
+def _normalize_query_filters(filters: QueryFilters) -> Optional[Dict[str, List[Any]]]:
+    """Normalize query filters into a dict-of-lists.
+
+    The Nautobot API (via pynautobot) accepts either scalar values or lists of values.
+    This plugin normalizes to a dict-of-lists to keep merge semantics consistent.
+
+    Examples:
+        - {} or None: no filtering
+        - {"name": "name one"}: single filter value
+        - {"name": ["name one", "name two"]}: multiple values for same key
+
+    Returns:
+        dict or None: A dict of query params where each value is a list, or None when empty.
+
+    Raises:
+        TypeError: If filters are not a dict.
+    """
+    if filters is None or filters == {}:
+        return None
+
+    if not isinstance(filters, dict):
+        raise TypeError("query_filters must be a dict")
+
+    normalized: Dict[str, List[Any]] = {}
+    for key, value in filters.items():
+        if isinstance(value, list):
+            normalized[key] = value
+        else:
+            normalized[key] = [value]
+
+    return normalized or None
+
+
+def _merge_query_filters(
+    base: Optional[Dict[str, List[Any]]],
+    extra: Optional[Dict[str, List[Any]]],
+) -> Optional[Dict[str, List[Any]]]:
+    """Merge two dict-of-lists filter dicts.
+
+    When a key exists in both dicts, values are concatenated.
+    """
+    if base is None and extra is None:
+        return None
+    if base is None:
+        return extra or None
+    if extra is None:
+        return base or None
+
+    merged: Dict[str, List[Any]] = {}
+    for key, value in base.items():
+        if not isinstance(value, list):
+            raise TypeError(
+                f"query_filters must be a dict of lists; key '{key}' must be a list (got {type(value).__name__})"
+            )
+        merged[key] = list(value)
+
+    for key, value in extra.items():
+        if not isinstance(value, list):
+            raise TypeError(
+                f"query_filters must be a dict of lists; key '{key}' must be a list (got {type(value).__name__})"
+            )
+
+        if key in merged:
+            merged[key].extend(value)
+        else:
+            merged[key] = list(value)
+
+    return merged or None
 
 
 def _set_host(data: Dict[str, Any], name: str, groups, host, defaults: Defaults) -> Host:
@@ -51,6 +124,49 @@ def _set_host(data: Dict[str, Any], name: str, groups, host, defaults: Defaults)
     )
 
 
+def _add_host_to_inventory(
+    hosts: Hosts,
+    defaults: Defaults,
+    nautobot_object,
+    *,
+    is_virtual: bool,
+    pynautobot_dict: Union[bool, None],
+):
+    host: Dict[Any, Any] = {"data": {}}
+
+    # Assign the pynautobot host object to the data key
+    host["data"]["pynautobot_object"] = nautobot_object
+    host["data"]["is_virtual"] = is_virtual
+
+    # Create dictionary object available for filtering
+    if pynautobot_dict:
+        host["data"]["pynautobot_dictionary"] = dict(nautobot_object)
+
+    # Add primary IP address if found
+    # Otherwise use object name as hostname
+    host["hostname"] = (
+        str(ipaddress.IPv4Interface(nautobot_object.primary_ip4.address).ip)
+        if nautobot_object["primary_ip4"]
+        else (
+            str(ipaddress.IPv6Interface(nautobot_object.primary_ip6.address).ip)
+            if nautobot_object["primary_ip6"]
+            else nautobot_object["name"]
+        )
+    )
+    host["name"] = nautobot_object.name or str(nautobot_object.id)
+    host["groups"] = []
+
+    inventory_key = nautobot_object.name or str(nautobot_object.id)
+    # TODO: Devices and VMs can share names; this overwrites (Ansible-like behavior)
+    hosts[inventory_key] = _set_host(  # pylint: disable=unsupported-assignment-operation
+        data=host["data"],
+        name=host["name"],
+        groups=host["groups"],
+        host=host,
+        defaults=defaults,
+    )
+
+
 # Setup connection to Nautobot
 class NautobotInventory:  # pylint: disable=R0902
     """Nautobot Nornir Inventory."""
@@ -63,17 +179,29 @@ class NautobotInventory:  # pylint: disable=R0902
         filter_parameters: Union[Dict[str, Any], None] = None,
         pynautobot_dict: Union[bool, None] = True,
         enable_threading: Union[bool, None] = False,
+        query_filters: QueryFilters = None,
+        device_query_filters: QueryFilters = None,
+        vm_query_filters: QueryFilters = None,
     ) -> None:
         """Nautobot nornir class initialization."""
         self.nautobot_url = nautobot_url or os.getenv("NAUTOBOT_URL")
         self.nautobot_token = nautobot_token or os.getenv("NAUTOBOT_TOKEN")
+
+        # Legacy device-only filters
         self.filter_parameters = filter_parameters
+
+        # New filtering model
+        self.query_filters = query_filters
+        self.device_query_filters = device_query_filters
+        self.vm_query_filters = vm_query_filters
+
         self.ssl_verify = ssl_verify
         self.pynautobot_dict = pynautobot_dict
         self.enable_threading = enable_threading
         self._verify_required()
         self._api_session = None
         self._devices = None
+        self._virtual_machines = None
         self._pynautobot_obj = None
 
     def _verify_required(self) -> bool:
@@ -120,21 +248,57 @@ class NautobotInventory:  # pylint: disable=R0902
 
         return self._pynautobot_obj
 
+    def _query_filters_for_devices(self) -> Optional[Dict[str, Any]]:
+        shared = _normalize_query_filters(self.query_filters)
+        legacy_device_only = _normalize_query_filters(self.filter_parameters)
+        explicit_device_only = _normalize_query_filters(self.device_query_filters)
+
+        merged = _merge_query_filters(shared, legacy_device_only)
+        return _merge_query_filters(merged, explicit_device_only)
+
+    def _query_filters_for_virtual_machines(self) -> Optional[Dict[str, Any]]:
+        shared = _normalize_query_filters(self.query_filters)
+        vm_only = _normalize_query_filters(self.vm_query_filters)
+        return _merge_query_filters(shared, vm_only)
+
     @property
     def devices(self) -> list:
         """Devices information from Nautobot."""
         if self._devices is None:
-            # Check for filters. Cannot pass an empty dictionary to the filter method
-            if self.filter_parameters is None:
+            filters = self._query_filters_for_devices()
+            # Cannot pass an empty dictionary to the filter method
+            if filters is None:
                 self._devices = self.pynautobot_obj.dcim.devices.all()
             else:
                 try:
-                    self._devices = self.pynautobot_obj.dcim.devices.filter(**self.filter_parameters)
+                    self._devices = self.pynautobot_obj.dcim.devices.filter(**filters)
                 except pynautobot.core.query.RequestError as err:
                     print(f"Error in the query filters: {err.error}. Please verify the parameters.")
                     sys.exit(1)
 
         return self._devices
+
+    @property
+    def virtual_machines(self) -> list:
+        """Virtual Machines information from Nautobot."""
+        if self._virtual_machines is None:
+            # Backwards compatibility, filter_parameters applies to Devices only
+            # Do not include VMs unless VM/both filters are set
+            if self.filter_parameters is not None and self.query_filters is None and self.vm_query_filters is None:
+                self._virtual_machines = []
+                return self._virtual_machines
+
+            filters = self._query_filters_for_virtual_machines()
+            if filters is None:
+                self._virtual_machines = self.pynautobot_obj.virtualization.virtual_machines.all()
+            else:
+                try:
+                    self._virtual_machines = self.pynautobot_obj.virtualization.virtual_machines.filter(**filters)
+                except pynautobot.core.query.RequestError as err:
+                    print(f"Error in the query filters: {err.error}. Please verify the parameters.")
+                    sys.exit(1)
+
+        return self._virtual_machines
 
     # Build the inventory
     def load(self) -> Inventory:
@@ -148,37 +312,15 @@ class NautobotInventory:  # pylint: disable=R0902
         defaults = Defaults()
 
         for device in self.devices:
-            # Set the base information for a device
-            host: Dict[Any, Any] = {"data": {}}
+            _add_host_to_inventory(hosts, defaults, device, is_virtual=False, pynautobot_dict=self.pynautobot_dict)
 
-            # Assign the pynautobot host object to the data key
-            host["data"]["pynautobot_object"] = device
-
-            # Create dictionary object available for filtering
-            if self.pynautobot_dict:
-                host["data"]["pynautobot_dictionary"] = dict(device)
-            # TODO: #3 Investigate Nornir compatability with dictionary like object
-
-            # Add Primary IP address, if found. Otherwise add hostname as the device name
-            host["hostname"] = (
-                str(ipaddress.IPv4Interface(device.primary_ip4.address).ip)
-                if device["primary_ip4"]
-                else (
-                    str(ipaddress.IPv6Interface(device.primary_ip6.address).ip)
-                    if device["primary_ip6"]
-                    else device["name"]
-                )
-            )
-            host["name"] = device.name or str(device.id)
-            host["groups"] = []
-
-            # Add host to hosts by name first, ID otherwise - to string
-            hosts[device.name or str(device.id)] = _set_host(  # pylint: disable=unsupported-assignment-operation
-                data=host["data"],
-                name=host["name"],
-                groups=host["groups"],
-                host=host,
-                defaults=defaults,
+        for virtual_machine in self.virtual_machines:
+            _add_host_to_inventory(
+                hosts,
+                defaults,
+                virtual_machine,
+                is_virtual=True,
+                pynautobot_dict=self.pynautobot_dict,
             )
 
         return Inventory(hosts=hosts, groups=groups, defaults=defaults)

--- a/tests/unit/mocks/08_get_virtual_machines.json
+++ b/tests/unit/mocks/08_get_virtual_machines.json
@@ -1,0 +1,81 @@
+{
+    "count": 2,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 100,
+            "url": "http://nautobot-demo.com/api/virtualization/virtual-machines/100/",
+            "name": "vm-app01",
+            "display": "vm-app01",
+            "cluster": {
+                "id": 1,
+                "url": "http://nautobot-demo.com/api/virtualization/clusters/1/",
+                "name": "cluster-1"
+            },
+            "tenant": null,
+            "platform": {
+                "id": 10,
+                "url": "http://nautobot-demo.com/api/dcim/platforms/10/",
+                "name": "Linux",
+                "network_driver": "linux"
+            },
+            "status": {
+                "value": "active",
+                "label": "Active"
+            },
+            "role": null,
+            "primary_ip4": {
+                "id": 100,
+                "url": "http://nautobot-demo.com/api/ipam/ip-addresses/100/",
+                "family": 4,
+                "address": "10.50.0.10/32"
+            },
+            "primary_ip6": null,
+            "comments": "",
+            "local_config_context_data": null,
+            "tags": [],
+            "custom_fields": {},
+            "config_context": {},
+            "created": "2020-12-06",
+            "last_updated": "2020-12-13T20:33:30.187336Z"
+        },
+        {
+            "id": 101,
+            "url": "http://nautobot-demo.com/api/virtualization/virtual-machines/101/",
+            "name": "vm-db01",
+            "display": "vm-db01",
+            "cluster": {
+                "id": 1,
+                "url": "http://nautobot-demo.com/api/virtualization/clusters/1/",
+                "name": "cluster-1"
+            },
+            "tenant": null,
+            "platform": {
+                "id": 10,
+                "url": "http://nautobot-demo.com/api/dcim/platforms/10/",
+                "name": "Linux",
+                "network_driver": "linux"
+            },
+            "status": {
+                "value": "active",
+                "label": "Active"
+            },
+            "role": null,
+            "primary_ip4": {
+                "id": 101,
+                "url": "http://nautobot-demo.com/api/ipam/ip-addresses/101/",
+                "family": 4,
+                "address": "10.50.0.11/32"
+            },
+            "primary_ip6": null,
+            "comments": "",
+            "local_config_context_data": null,
+            "tags": [],
+            "custom_fields": {},
+            "config_context": {},
+            "created": "2020-12-06",
+            "last_updated": "2020-12-13T20:33:30.187336Z"
+        }
+    ]
+}

--- a/tests/unit/mocks/09_get_virtual_machine_vm-app01.json
+++ b/tests/unit/mocks/09_get_virtual_machine_vm-app01.json
@@ -1,0 +1,44 @@
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 100,
+            "url": "http://nautobot-demo.com/api/virtualization/virtual-machines/100/",
+            "name": "vm-app01",
+            "display": "vm-app01",
+            "cluster": {
+                "id": 1,
+                "url": "http://nautobot-demo.com/api/virtualization/clusters/1/",
+                "name": "cluster-1"
+            },
+            "tenant": null,
+            "platform": {
+                "id": 10,
+                "url": "http://nautobot-demo.com/api/dcim/platforms/10/",
+                "name": "Linux",
+                "network_driver": "linux"
+            },
+            "status": {
+                "value": "active",
+                "label": "Active"
+            },
+            "role": null,
+            "primary_ip4": {
+                "id": 100,
+                "url": "http://nautobot-demo.com/api/ipam/ip-addresses/100/",
+                "family": 4,
+                "address": "10.50.0.10/32"
+            },
+            "primary_ip6": null,
+            "comments": "",
+            "local_config_context_data": null,
+            "tags": [],
+            "custom_fields": {},
+            "config_context": {},
+            "created": "2020-12-06",
+            "last_updated": "2020-12-13T20:33:30.187336Z"
+        }
+    ]
+}

--- a/tests/unit/mocks/10_get_virtual_machine_vm-db01.json
+++ b/tests/unit/mocks/10_get_virtual_machine_vm-db01.json
@@ -1,0 +1,44 @@
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 101,
+            "url": "http://nautobot-demo.com/api/virtualization/virtual-machines/101/",
+            "name": "vm-db01",
+            "display": "vm-db01",
+            "cluster": {
+                "id": 1,
+                "url": "http://nautobot-demo.com/api/virtualization/clusters/1/",
+                "name": "cluster-1"
+            },
+            "tenant": null,
+            "platform": {
+                "id": 10,
+                "url": "http://nautobot-demo.com/api/dcim/platforms/10/",
+                "name": "Linux",
+                "network_driver": "linux"
+            },
+            "status": {
+                "value": "active",
+                "label": "Active"
+            },
+            "role": null,
+            "primary_ip4": {
+                "id": 101,
+                "url": "http://nautobot-demo.com/api/ipam/ip-addresses/101/",
+                "family": 4,
+                "address": "10.50.0.11/32"
+            },
+            "primary_ip6": null,
+            "comments": "",
+            "local_config_context_data": null,
+            "tags": [],
+            "custom_fields": {},
+            "config_context": {},
+            "created": "2020-12-06",
+            "last_updated": "2020-12-13T20:33:30.187336Z"
+        }
+    ]
+}

--- a/tests/unit/mocks/11_get_virtual_machines_filtered.json
+++ b/tests/unit/mocks/11_get_virtual_machines_filtered.json
@@ -1,0 +1,44 @@
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 100,
+            "url": "http://nautobot-demo.com/api/virtualization/virtual-machines/100/",
+            "name": "vm-app01",
+            "display": "vm-app01",
+            "cluster": {
+                "id": 1,
+                "url": "http://nautobot-demo.com/api/virtualization/clusters/1/",
+                "name": "cluster-1"
+            },
+            "tenant": null,
+            "platform": {
+                "id": 10,
+                "url": "http://nautobot-demo.com/api/dcim/platforms/10/",
+                "name": "Linux",
+                "network_driver": "linux"
+            },
+            "status": {
+                "value": "active",
+                "label": "Active"
+            },
+            "role": null,
+            "primary_ip4": {
+                "id": 100,
+                "url": "http://nautobot-demo.com/api/ipam/ip-addresses/100/",
+                "family": 4,
+                "address": "10.50.0.10/32"
+            },
+            "primary_ip6": null,
+            "comments": "",
+            "local_config_context_data": null,
+            "tags": [],
+            "custom_fields": {},
+            "config_context": {},
+            "created": "2020-12-06",
+            "last_updated": "2020-12-13T20:33:30.187336Z"
+        }
+    ]
+}

--- a/tests/unit/test_nautobot_inventory.py
+++ b/tests/unit/test_nautobot_inventory.py
@@ -45,6 +45,11 @@ API_CALLS = [
         "method": "get",
     },
     {
+        "fixture_path": f"{HERE}/mocks/01_get_devices.json",
+        "url": "http://mock.example.com/api/dcim/devices/?depth=1&limit=0",
+        "method": "get",
+    },
+    {
         "fixture_path": f"{HERE}/mocks/02_get_device1.json",
         "url": "http://mock.example.com/api/dcim/devices/?name=den-dist01",
         "method": "get",
@@ -72,6 +77,51 @@ API_CALLS = [
     {
         "fixture_path": f"{HERE}/mocks/07_get_device_msp-rtr02.json",
         "url": "http://mock.example.com/api/dcim/devices/?name=msp-rtr02",
+        "method": "get",
+    },
+    {
+        "fixture_path": f"{HERE}/mocks/08_get_virtual_machines.json",
+        "url": "http://mock.example.com/api/virtualization/virtual-machines/?depth=1",
+        "method": "get",
+    },
+    {
+        "fixture_path": f"{HERE}/mocks/08_get_virtual_machines.json",
+        "url": "https://mock.example.com/api/virtualization/virtual-machines/?depth=1",
+        "method": "get",
+    },
+    {
+        "fixture_path": f"{HERE}/mocks/08_get_virtual_machines.json",
+        "url": "http://mock.example.com/api/virtualization/virtual-machines/?depth=1&limit=0",
+        "method": "get",
+    },
+    {
+        "fixture_path": f"{HERE}/mocks/08_get_virtual_machines.json",
+        "url": "https://mock.example.com/api/virtualization/virtual-machines/?depth=1&limit=0",
+        "method": "get",
+    },
+    {
+        "fixture_path": f"{HERE}/mocks/09_get_virtual_machine_vm-app01.json",
+        "url": "http://mock.example.com/api/virtualization/virtual-machines/?name=vm-app01",
+        "method": "get",
+    },
+    {
+        "fixture_path": f"{HERE}/mocks/10_get_virtual_machine_vm-db01.json",
+        "url": "http://mock.example.com/api/virtualization/virtual-machines/?name=vm-db01",
+        "method": "get",
+    },
+    {
+        "fixture_path": f"{HERE}/mocks/11_get_virtual_machines_filtered.json",
+        "url": "http://mock.example.com/api/virtualization/virtual-machines/?depth=1&name=vm-app01",
+        "method": "get",
+    },
+    {
+        "fixture_path": f"{HERE}/mocks/01_get_devices.json",
+        "url": "http://mock.example.com/api/dcim/devices/?depth=1&status=active",
+        "method": "get",
+    },
+    {
+        "fixture_path": f"{HERE}/mocks/08_get_virtual_machines.json",
+        "url": "http://mock.example.com/api/virtualization/virtual-machines/?depth=1&status=active",
         "method": "get",
     },
 ]
@@ -182,6 +232,7 @@ def test_filter_devices():
             expected_devices.append(pynautobot_obj.dcim.devices.get(name=device))
 
         assert test_class.devices == expected_devices
+        assert test_class.virtual_machines == []
 
 
 def test_device_required_properties():
@@ -214,7 +265,7 @@ def test_device_required_properties():
         assert nornir_task_result[task_result].result == "ios"
 
 
-def test_nornir_nautobot_device_count():
+def test_nornir_nautobot_host_count():
     # Import mock requests
     with Mocker() as mock:
         load_api_calls(mock)
@@ -228,8 +279,8 @@ def test_nornir_nautobot_device_count():
             },
         )
 
-    # Verify that the length of the inventory is 3 devices
-    assert len(test_nornir.inventory.hosts) == 3
+    # Verify that the length of the inventory is 3 devices + 2 virtual machines
+    assert len(test_nornir.inventory.hosts) == 5
 
 
 def test_nornir_nautobot_with_defaults():
@@ -356,3 +407,86 @@ def test_no_pynautobot_as_dict(device):
             logging={"enabled": False},
         )
         assert "pynautobot_dictionary" not in list(nornir_no_pynb_dict.inventory.hosts[device].keys())
+
+
+def test_virtual_machines(nornir_nautobot_class):
+    # Import mock requests
+    with Mocker() as mock:
+        load_api_calls(mock)
+        pynautobot_obj = pynautobot.api(url="http://mock.example.com", token="0123456789abcdef01234567890")
+        expected_virtual_machines = []
+        for virtual_machine in ["vm-app01", "vm-db01"]:
+            expected_virtual_machines.append(pynautobot_obj.virtualization.virtual_machines.get(name=virtual_machine))
+
+        assert nornir_nautobot_class.virtual_machines == expected_virtual_machines
+
+
+def test_nornir_nautobot_virtual_machine_hostname():
+    with Mocker() as mock:
+        load_api_calls(mock)
+        test_nornir = InitNornir(
+            inventory={
+                "plugin": "NautobotInventory",
+                "options": {
+                    "nautobot_url": "http://mock.example.com",
+                    "nautobot_token": "0123456789abcdef01234567890",
+                },
+            },
+        )
+
+    assert test_nornir.inventory.hosts["vm-app01"].hostname == "10.50.0.10"
+
+
+def test_nornir_nautobot_is_virtual_metadata():
+    with Mocker() as mock:
+        load_api_calls(mock)
+        test_nornir = InitNornir(
+            inventory={
+                "plugin": "NautobotInventory",
+                "options": {
+                    "nautobot_url": "http://mock.example.com",
+                    "nautobot_token": "0123456789abcdef01234567890",
+                },
+            },
+        )
+
+    assert test_nornir.inventory.hosts["den-dist01"]["is_virtual"] is False
+    assert test_nornir.inventory.hosts["vm-app01"]["is_virtual"] is True
+
+
+def test_vm_query_filters_only():
+    with Mocker() as mock:
+        load_api_calls(mock)
+        test_nornir = InitNornir(
+            inventory={
+                "plugin": "NautobotInventory",
+                "options": {
+                    "nautobot_url": "http://mock.example.com",
+                    "nautobot_token": "0123456789abcdef01234567890",
+                    "vm_query_filters": {"name": "vm-app01"},
+                },
+            },
+        )
+
+    assert "vm-app01" in test_nornir.inventory.hosts
+    assert "vm-db01" not in test_nornir.inventory.hosts
+    assert "den-dist01" in test_nornir.inventory.hosts
+    assert "den-dist02" in test_nornir.inventory.hosts
+    assert "den-wan01" in test_nornir.inventory.hosts
+
+
+def test_query_filters_applied_to_devices_and_virtual_machines():
+    with Mocker() as mock:
+        load_api_calls(mock)
+        test_nornir = InitNornir(
+            inventory={
+                "plugin": "NautobotInventory",
+                "options": {
+                    "nautobot_url": "http://mock.example.com",
+                    "nautobot_token": "0123456789abcdef01234567890",
+                    "query_filters": {"status": "active"},
+                },
+            },
+        )
+
+    assert len(test_nornir.inventory.hosts) == 5


### PR DESCRIPTION
Heavily influenced by current Ansible behaviors, see https://github.com/nautobot/nautobot-ansible
- A duplicated VM / Device name may collide, and behavior is to override
- Maintained dict of lists for AND/OR behavior of API from nornir rather than Ansible.
- Scaffolding / merging functions to support 3 separate query types
- Coerce scalar into list to support merging of multiple filters. 

Resolves #251 