### PR TITLE
Arista - unconverted command error match

### DIFF
--- a/changes/279.fixed
+++ b/changes/279.fixed
@@ -1,0 +1,1 @@
+Added error handling for Arista's unconverted commands.

--- a/nornir_nautobot/constants.py
+++ b/nornir_nautobot/constants.py
@@ -12,6 +12,7 @@ ERROR_MATCHES_BAD_COMMAND = [
     "% Ambiguous command",
     "% Incomplete command",
     "% Invalid input detected at",
+    "% This is an unconverted command",
     "% Too many parameters found at",
     "% Unrecognized command found at",
     "% Wrong parameter found at",


### PR DESCRIPTION
Closes #279 

Arista issues `% This is an unconverted command` message on `| json` commands that JSON outputs are not supported.

For those cases, this results in Device Onboarding crash without proper error handling.

