### PR TITLE
fix towncrier for auto release pipeline

### DIFF
--- a/changes/+fix-towncrier.housekeeping
+++ b/changes/+fix-towncrier.housekeeping
@@ -1,0 +1,1 @@
+Fixed incorrect towncrier package name.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ testpaths = [
 addopts = "-vv --doctest-modules -p no:warnings --ignore-glob='*mock*'"
 
 [tool.towncrier]
-package = "nornir-nautobot"
+package = "nornir_nautobot"
 directory = "changes"
 filename = "docs/admin/release_notes/version_X.Y.md"
 template = "towncrier_template.j2"


### PR DESCRIPTION
Before:
```
▶ poetry run towncrier build --version "4.2.1" --date "2026-04-23" --draft

Loading template...
Finding news fragments...
Rendering news fragments...
ERROR: tried to import nornir-nautobot, but ran into this error: No module named 'nornir-nautobot'
Traceback (most recent call last):
  File "/Users/jeffkala/Library/Caches/pypoetry/virtualenvs/nornir-nautobot-yKmAeRcq-py3.12/lib/python3.12/site-packages/towncrier/_project.py", line 21, in _get_package
    module = import_module(package)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'nornir-nautobot'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jeffkala/Library/Caches/pypoetry/virtualenvs/nornir-nautobot-yKmAeRcq-py3.12/bin/towncrier", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/jeffkala/Library/Caches/pypoetry/virtualenvs/nornir-nautobot-yKmAeRcq-py3.12/lib/python3.12/site-packages/click/core.py", line 1462, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jeffkala/Library/Caches/pypoetry/virtualenvs/nornir-nautobot-yKmAeRcq-py3.12/lib/python3.12/site-packages/click/core.py", line 1383, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/jeffkala/Library/Caches/pypoetry/virtualenvs/nornir-nautobot-yKmAeRcq-py3.12/lib/python3.12/site-packages/click/core.py", line 1850, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jeffkala/Library/Caches/pypoetry/virtualenvs/nornir-nautobot-yKmAeRcq-py3.12/lib/python3.12/site-packages/click/core.py", line 1246, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jeffkala/Library/Caches/pypoetry/virtualenvs/nornir-nautobot-yKmAeRcq-py3.12/lib/python3.12/site-packages/click/core.py", line 814, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jeffkala/Library/Caches/pypoetry/virtualenvs/nornir-nautobot-yKmAeRcq-py3.12/lib/python3.12/site-packages/towncrier/build.py", line 123, in _main
    return __main(
           ^^^^^^^
  File "/Users/jeffkala/Library/Caches/pypoetry/virtualenvs/nornir-nautobot-yKmAeRcq-py3.12/lib/python3.12/site-packages/towncrier/build.py", line 200, in __main
    project_name = get_project_name(
                   ^^^^^^^^^^^^^^^^^
  File "/Users/jeffkala/Library/Caches/pypoetry/virtualenvs/nornir-nautobot-yKmAeRcq-py3.12/lib/python3.12/site-packages/towncrier/_project.py", line 95, in get_project_name
    module = _get_package(package_dir, package)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jeffkala/Library/Caches/pypoetry/virtualenvs/nornir-nautobot-yKmAeRcq-py3.12/lib/python3.12/site-packages/towncrier/_project.py", line 28, in _get_package
    module = import_module(package)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'nornir-nautobot'
```


After
```
▶ poetry run towncrier build --version "4.2.1" --date "2026-04-23" --draft

Loading template...
Finding news fragments...
Rendering news fragments...
Draft only -- nothing has been written.
What is seen below is what would be written.


# v4.2 Release Notes

This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## Release Overview

- Major features or milestones
- Changes to compatibility with Nautobot and/or other apps, libraries etc.

## [v4.2.1 (2026-04-23)](https://github.com/nautobot/nornir-nautobot/releases/tag/v4.2.1)

### Fixed

- [#264](https://github.com/nautobot/nornir-nautobot/issues/264) - Fixed issues with error checking function signature mismatches.

### Housekeeping

- [#283](https://github.com/nautobot/nornir-nautobot/issues/283) - Manually updated cookiecutter to the latest standard in preparation for drift management.
```