### PR TITLE
Fix merge_config save logging: assign E1016 error message, log save completion

### DIFF
--- a/changes/291.fixed
+++ b/changes/291.fixed
@@ -1,0 +1,1 @@
+Fixed the save step in the Netmiko `merge_config` logging a discarded error message on failure, and added a log message confirming when the configuration save has completed.

--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -834,8 +834,10 @@ class NetmikoDefault(DispatcherMixin):
             except (NotImplementedError, AttributeError, NornirExecutionError):
                 nr_without_processors.run(task=netmiko_commit)
         except NornirSubTaskError as exc:
-            get_error_message("E1016", exc=exc)
+            error_msg = get_error_message("E1016", exc=exc)
             logger.error(error_msg, extra={"object": obj})
+        else:
+            logger.info("Config save ended", extra={"object": obj})
         return Result(
             host=task.host,
             result={"changed": push_result[0].changed, "result": push_result[0].result},


### PR DESCRIPTION
Closes #291

## New Pull Request

Have you:
- [x] Updated the README if necessary? (no README changes needed)
- [x] Updated any configuration settings? (none affected)
- [ ] Written a unit test? (no existing test coverage for the `merge_config` save path; happy to add scaffolding if maintainers want it in this PR)

## Change Notes

Two small fixes to the save step at the end of `NetmikoDefault.merge_config`:

- Assigned the return value of `get_error_message("E1016", exc=exc)` to `error_msg` before logging it. Previously the computed message was discarded and the handler logged the leftover `error_msg` from the earlier `_has_hidden_errors()` call (typically `None`), so a failed config save logged `None` instead of the actual error.
- Added a `Config save ended` info log when the save subtask completes without error, mirroring the existing `Config merge ended` message. Previously a successful save was completely silent (the subtask intentionally runs without processors), leaving users unsure whether the running config was persisted.

## Justification

Surfaced by a community question in the Network to Code Slack asking whether Nautobot saves the running config after deploying a config plan — the asker had never seen a save confirmation because none is logged. Details and reproduction in #291.
