### PR TITLE
Fixed missing headings in the documentation

### DIFF
--- a/changes/299.documentation
+++ b/changes/299.documentation
@@ -1,0 +1,1 @@
+Fixed missing headings in the documentation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,7 +131,7 @@ nav:
       - Task Plugin:
           - Task Overview: "user/task.md"
           - Troubleshooting:
-              - "user/troubleshooting/index.md"
+              - Troubleshooting: "user/troubleshooting/index.md"
               - E1XXX: "user/troubleshooting/E1XXX.md"
               - E1000: "user/troubleshooting/E1000.md"
               - E1001: "user/troubleshooting/E1001.md"
@@ -176,7 +176,7 @@ nav:
       - Upgrade: "admin/upgrade.md"
       - Uninstall: "admin/uninstall.md"
       - Release Notes:
-          - "admin/release_notes/index.md"
+          - Release Notes: "admin/release_notes/index.md"
           - v4.3: "admin/release_notes/version_4.3.md"
           - v4.2: "admin/release_notes/version_4.2.md"
           - v4.1: "admin/release_notes/version_4.1.md"


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="287" height="124" alt="Screenshot 2026-08-04 at 3 23 19 PM" src="https://github.com/user-attachments/assets/39c847f8-6ff1-44f4-81bf-6ef47e29ffa9" />|<img width="292" height="192" alt="Screenshot 2026-08-04 at 3 25 40 PM" src="https://github.com/user-attachments/assets/ba9c4f13-7d02-462b-a5d0-f57996ad4556" />|
|<img width="249" height="168" alt="Screenshot 2026-08-04 at 3 23 27 PM" src="https://github.com/user-attachments/assets/793d9a19-6123-4977-ab0c-80b4c428d5a0" />|<img width="302" height="285" alt="Screenshot 2026-08-04 at 3 25 48 PM" src="https://github.com/user-attachments/assets/9cefa4f8-557d-4dff-aff7-ca38c98c4158" />|
