### PR TITLE
Add dynamic config_command support to the Scrapli dispatcher

### DIFF
--- a/changes/296.added
+++ b/changes/296.added
@@ -1,0 +1,1 @@
+Added dynamic `config_command` support to the Scrapli dispatcher, resolving per-device overrides from the `config_command` custom field or config context before falling back to the dispatcher default.

--- a/docs/user/task.md
+++ b/docs/user/task.md
@@ -101,16 +101,16 @@ class DispatcherMixin:
         return cls.tcp_port
 ```
 
-## Netmiko Show Running Config Command
+## Show Running Config Command
 
-The Netmiko `show_command` tells Netmiko which command to use to get the config, generally used to backup the configuration. You can override the default provided based on this logic:
+The `config_command` tells the dispatcher which command to use to get the config, generally used to backup the configuration. Both the Netmiko and Scrapli dispatchers support overriding the default provided based on this logic:
 
 - First prefer `obj.cf["config_command"]` if it is set and a valid string, which is to say if a custom field named `config_command` is present it should be preferred.
 - Second prefer `obj.get_config_context()["config_command"]` if it is set and a valid string, which is to say if a config context is rendered for this device named `config_command` is present it should be preferred.
-- Third prefer the command defined in your Netmiko dispatcher.
-- Finally default to what `RUNNING_CONFIG_MAPPER` (which comes from `netutils`) has in that dictionary or simply default to `show run`
+- Third prefer the command defined in your dispatcher.
+- Finally, for Netmiko, default to what `RUNNING_CONFIG_MAPPER` (which comes from `netutils`) has in that dictionary or simply default to `show run`. For Scrapli, default to `show run`.
 
-Here is the implementation:
+Here is the Netmiko implementation:
 
 ```python
 config_command = None
@@ -128,6 +128,8 @@ def _get_config_command(cls, obj) -> str:
         return cls.config_command
     return RUNNING_CONFIG_MAPPER.get(str(obj.platform), "show run")
 ```
+
+The Scrapli implementation follows the same precedence but always defaults to its class attribute `config_command`, which is `"show run"`.
 
 ## Get command outputs through git repository
 

--- a/nornir_nautobot/plugins/tasks/dispatcher/default.py
+++ b/nornir_nautobot/plugins/tasks/dispatcher/default.py
@@ -1036,6 +1036,18 @@ class ScrapliDefault(DispatcherMixin):
     config_command = "show run"
 
     @classmethod
+    def _get_config_command(cls, obj) -> str:
+        custom_field = obj.cf.get("config_command")
+        if custom_field and isinstance(custom_field, str):
+            return custom_field
+        config_context = obj.get_config_context().get("config_command")
+        if config_context and isinstance(config_context, str):
+            return config_context
+        if cls.config_command:
+            return cls.config_command
+        return "show run"
+
+    @classmethod
     def get_config(  # pylint: disable=too-many-positional-arguments
         cls,
         task: Task,
@@ -1062,7 +1074,7 @@ class ScrapliDefault(DispatcherMixin):
                 { "config: <running configuration> }
         """
         logger.debug(f"Executing get_config for {task.host.name} on {task.host.platform}")
-        command = cls.config_command
+        command = cls._get_config_command(obj)
         if cls._offline_commands(obj):
             getter_result = cls.get_command(task, logger, obj, command, command_file_path=command_file_path)
         else:

--- a/tests/unit/test_offline_commands.py
+++ b/tests/unit/test_offline_commands.py
@@ -253,3 +253,35 @@ def test_scrapli_get_command_force_offline_overrides_explicit_false_offline_comm
     )
     assert result.result == {"output": {"show run": "hostname router1"}}
     assert task.run.call_args.kwargs["task"] == ScrapliDefault.get_git_command
+
+
+# --- ScrapliDefault dynamic config_command resolution ---
+
+
+def test_scrapli_get_config_command_uses_custom_field():
+    obj = _make_obj(
+        custom_fields={"config_command": "show running-config"}, config_context={"config_command": "show run"}
+    )
+    assert ScrapliDefault._get_config_command(obj) == "show running-config"
+
+
+def test_scrapli_get_config_command_uses_config_context_when_cf_absent():
+    obj = _make_obj(config_context={"config_command": "show configuration | display set"})
+    assert ScrapliDefault._get_config_command(obj) == "show configuration | display set"
+
+
+def test_scrapli_get_config_command_uses_class_default():
+    assert ScrapliDefault._get_config_command(_make_obj()) == "show run"
+
+
+def test_scrapli_get_config_command_ignores_non_string_values():
+    obj = _make_obj(
+        custom_fields={"config_command": ["show run"]},
+        config_context={"config_command": 42},
+    )
+    assert ScrapliDefault._get_config_command(obj) == "show run"
+
+
+def test_scrapli_get_config_command_non_string_cf_falls_through_to_context():
+    obj = _make_obj(custom_fields={"config_command": 42}, config_context={"config_command": "show running-config"})
+    assert ScrapliDefault._get_config_command(obj) == "show running-config"


### PR DESCRIPTION
## New Pull Request

Have you:
- [x] Updated the README if necessary?
- [x] Updated any configuration settings?
- [x] Written a unit test?

## Change Notes

Fixes #296

`ScrapliDefault` previously hardcoded `config_command = "show run"`, so Scrapli users could not override the command used to retrieve a device's running configuration without writing a custom dispatcher. This PR gives the Scrapli dispatcher the same dynamic resolution that `NetmikoDefault` already has.

**Changes:**

- Added `ScrapliDefault._get_config_command()` (default.py:1038), mirroring the Netmiko implementation.
- `ScrapliDefault.get_config()` now uses `_get_config_command(obj)` instead of reading `cls.config_command` directly.
- Updated `docs/user/task.md` ("Show Running Config Command" section) to document Scrapli alongside Netmiko.
- Added towncrier changelog fragment `changes/296.added`.
- Added 5 unit tests covering the precedence and non-string handling.

**Notes:**
- Unlike Netmiko, Scrapli does not consult `RUNNING_CONFIG_MAPPER` (netutils has no scrapli-keyed entries); the class default `"show run"` covers the fallback.
- No change to Netmiko behavior — this is a copy, not a shared refactor.

## Justification

Scrapli users like me need per-device override of the running-config command (e.g. `show running-config`, `show configuration | display set`) the same way Netmiko users get it. Today that requires a custom dispatcher; this makes it a first-class option.
